### PR TITLE
Увеличить срок бесплатного пробного периода до 30 дней

### DIFF
--- a/my_telegram_bot.py
+++ b/my_telegram_bot.py
@@ -29,7 +29,7 @@ YOOKASSA_SHOP_ID = os.getenv("YOOKASSA_SHOP_ID")
 YOOKASSA_SECRET_KEY = os.getenv("YOOKASSA_SECRET_KEY")
 BASE_PRICE_PER_MONTH = Decimal(os.getenv("BASE_PRICE_PER_MONTH", "160.00"))
 # Длительность бесплатного пробного периода в днях
-FREE_TRIAL_DAYS = 7 
+FREE_TRIAL_DAYS = 30
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO


### PR DESCRIPTION
Изменена переменная `FREE_TRIAL_DAYS` с 7 на 30 в файле `my_telegram_bot.py`. Это изменение позволяет новым пользователям получать бесплатный VPN-ключ сроком на один месяц вместо одной недели.

Проверка кода подтвердила, что данное изменение затрагивает только логику выдачи бесплатных ключей и не влияет на платные подписки.